### PR TITLE
Added phone number verification method

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -20,6 +20,7 @@ export let messages = {
   alpha_dash: ':name can only contain letters and dashes',
   alpha: ':name can only contain leters',
   email: ':name must be correct mail',
+  phone: ':name must be a correct phone number',
   in_array: ':name is invalid',
   not_in: ":name can't be :value",
   json: ':name must be valid json',

--- a/src/methods.js
+++ b/src/methods.js
@@ -121,6 +121,14 @@ export let methods = {
     return emailRegex.test(value) || { value };
   },
 
+   /**
+   * @param value
+   * @return {boolean|{value}}
+   */
+  phone(value) {
+    return (/^\d{7,}$/).test(value.replace(/[\s()+\-\.]|ext/gi, ''));
+  },
+
   /**
    * @param value
    * @param suffix

--- a/src/methods.js
+++ b/src/methods.js
@@ -123,7 +123,7 @@ export let methods = {
 
    /**
    * @param value
-   * @return {boolean|{value}}
+   * @return {boolean}
    */
   phone(value) {
     return (/^\d{7,}$/).test(value.replace(/[\s()+\-\.]|ext/gi, ''));


### PR DESCRIPTION
Based on [this StackOverflow answer's regex](https://stackoverflow.com/a/4147641/12034488) added a verification for a phone number which requires at minimum 7 digits after removing +s or other symbols at the start of the phone value.